### PR TITLE
[EKA-000] Debuggable flag not set to false on release

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,16 +16,19 @@ android {
 
     buildTypes {
         debug {
+            debuggable true
             resValue 'string', 'app_name', 'Jataayu Debug'
             applicationIdSuffix '.debug'
         }
         qa {
+            debuggable true
             shrinkResources true
             minifyEnabled true
             applicationIdSuffix '.qa'
             resValue 'string', 'app_name', 'Jataayu QA'
         }
         release {
+            debuggable false
             shrinkResources true
             minifyEnabled true
             resValue 'string', 'app_name', 'Jataayu'


### PR DESCRIPTION
Fix issue where debuggable was set to true for all variants, it's false now for release preventing logs