### PR TITLE
[CM_APP_59]:Fix wrong message displayed when account is locked

### DIFF
--- a/user/resetPassword/src/main/java/in/projecteka/resetpassword/ui/fragment/ResetPasswordOtpFragment.kt
+++ b/user/resetPassword/src/main/java/in/projecteka/resetpassword/ui/fragment/ResetPasswordOtpFragment.kt
@@ -111,21 +111,22 @@ class ResetPasswordOtpFragment : BaseFragment() {
                 is PartialFailure -> {
                     if (it.error?.code == ERROR_CODE_INVALID_OTP || it.error?.code == ERROR_CODE_OTP_EXPIRED || it.error?.code == EXCEEDED_INVALID_ATTEMPT_LIMIT) {
                         viewModel.otpText.set(null)
+                        viewModel.errorLbl.set(
+                            when (it.error?.code) {
+                                ERROR_CODE_INVALID_OTP -> {
+                                    getString(R.string.invalid_otp)
+                                }
+                                ERROR_CODE_OTP_EXPIRED -> {
+                                    getString(R.string.otp_expired)
+                                }
+                                EXCEEDED_INVALID_ATTEMPT_LIMIT -> {
+                                    getString(R.string.exceeded_otp_attempt_limit)
+                                }
+                                else -> it.error?.message
+                            }
+                        )
                     }
-                    viewModel.errorLbl.set(
-                        when (it.error?.code) {
-                            ERROR_CODE_INVALID_OTP -> {
-                                getString(R.string.invalid_otp)
-                            }
-                            ERROR_CODE_OTP_EXPIRED -> {
-                                getString(R.string.otp_expired)
-                            }
-                            EXCEEDED_INVALID_ATTEMPT_LIMIT -> {
-                                getString(R.string.exceeded_otp_attempt_limit)
-                            }
-                            else -> it.error?.message
-                        }
-                    )
+
                     if(it.error?.code == ERROR_CODE_ACCOUNT_LOCKED){
                         viewModel.showAccountLockedError.set(true)
                     }

--- a/user/resetPassword/src/main/res/layout/reset_password_otp_verification.xml
+++ b/user/resetPassword/src/main/res/layout/reset_password_otp_verification.xml
@@ -35,7 +35,7 @@
             android:drawablePadding="@dimen/content_margin_medium"
             android:padding="16dp"
             android:layout_marginBottom="18dp"
-            android:text="@string/account_lock"
+            android:text="@string/reset_password_lock"
             app:toggledVisibility="@{viewModel.showAccountLockedError}"/>
 
 

--- a/user/resetPassword/src/main/res/values/strings.xml
+++ b/user/resetPassword/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="create_password">Create password</string>
     <string name="confirm_password">Confirm password</string>
     <string name="confirm">Confirm</string>
-    <string name="account_lock">Your account has been locked due to invalid attempts. Please try again after sometime.</string>
+    <string name="reset_password_lock">You cannot reset the password until account is locked. Please try after sometime.</string>
     <string name="password_validation_hint">Minimum length 8\nIt must contain one capital letter, one small letter, one number\nIt must also contain one special character</string>
     <string name="password_mismatch">Password doesn\'t match</string>
     <string name="password_match">Password matches</string>


### PR DESCRIPTION
Bug raised by Monica. Lock message is not correct as per story and also two messages are showing.